### PR TITLE
Set blockSize to 512

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hanwen/go-mtpfs/mtp"
 )
 
-const blockSize = 1024
+const blockSize = 512
 
 type DeviceFsOptions struct {
 	// Assume removable volumes are VFAT and munge filenames


### PR DESCRIPTION
This fixes size reported by du, which assumes blocks are given in 512
byte pieces
